### PR TITLE
Fix touch query (missing $) causing Postgresql syntax error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -277,8 +277,8 @@ module.exports = function (session) {
     this.query(
       `UPDATE ${this.quotedTable()}
         SET ${this.columns.expire} = to_timestamp($1)
-        WHERE {this.columns.session_id} = $2
-        RETURNING {this.columns.session_id}
+        WHERE ${this.columns.session_id} = $2
+        RETURNING ${this.columns.session_id}
       `,
       [expireTime, sessionId],
       function (err) { fn(err); }


### PR DESCRIPTION
Hi,

First of all, thanks for this module. After I started using it my Node console and Postgresql logs started filling with syntax errors: `syntax error at or near "{"`. Enabling query logging identified the culprit.
A further look identified the source of the problem in the `touch`-method. This pull request should fix that.
The string literal references to `this.columns.session_id` were missing a `$`.

Regards